### PR TITLE
Get organization identifiers from list of role types

### DIFF
--- a/oscm-extsvc-internal/src/main/java/org/oscm/internal/intf/OperatorService.java
+++ b/oscm-extsvc-internal/src/main/java/org/oscm/internal/intf/OperatorService.java
@@ -714,13 +714,13 @@ public interface OperatorService {
     Collection<VOSubscriptionUsageEntry> getSubscriptionUsageReport();
     
     /**
-     * Returns a String map of organization identifiers where each entry is a &lt;id, name&gt; pair from organizations of the given role type.
+     * Returns a String map of organization identifiers where each entry is a &lt;id, name&gt; pair from organizations of the given role types.
      * Note that since 18.1 the organization name is a mandatory attribute.   
      * 
      * @param r - the organizations role type of requested identifiers   
      * @return see above
      */
-    public default Map<String, String> getOrganizationIdentifiers(OrganizationRoleType r) {
+    public default Map<String, String> getOrganizationIdentifiers(List<OrganizationRoleType> l) {
         // Just a compile saving dummy
         // TODO remove default body when all OSCM repository implementations are available. 
         return Collections.emptyMap();


### PR DESCRIPTION
**Changes in this Pull Request:**
- Changed getOrganizationIdentifiers to receive a list of organization role types.

**Mandatory checks:**
- [x] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [x] changes were tested manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-interfaces/47)
<!-- Reviewable:end -->
